### PR TITLE
Added json schema for range plugin

### DIFF
--- a/benthomasson/eda/plugins/event_source/range_input_schema.json
+++ b/benthomasson/eda/plugins/event_source/range_input_schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://redhat.com/ansible_events/sources/range_input_schema.json",
+  "title": "Input of range Plugin",
+  "description": "A simple plugin to generate integer values given a limit",
+  "type": "object",
+  "properties": {
+      "limit": {
+           "description": "The max integer value",
+           "type": "integer"
+       }
+  },
+  "required": ["limit"]
+}

--- a/benthomasson/eda/plugins/event_source/range_output_schema.json
+++ b/benthomasson/eda/plugins/event_source/range_output_schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://redhat.com/ansible_events/sources/range_output_schema.json",
+  "title": "Output of range Plugin",
+  "description": "A simple plugin to generate integer values given a limit",
+  "type": "object",
+  "properties": {
+      "i": {
+           "description": "The current integer value",
+           "type": "integer"
+       }
+  },
+  "required": ["i"]
+}


### PR DESCRIPTION
The json schemas are in separate files one for input and one
for output. The input could most probably be used by the UI
the output is what would be sent to the drools engine as object
definition