### PR TITLE
Ensure arg 'delay' is always an integer

### DIFF
--- a/benthomasson/eda/plugins/event_source/url_check.py
+++ b/benthomasson/eda/plugins/event_source/url_check.py
@@ -27,7 +27,7 @@ from typing import Any, Dict
 async def main(queue: asyncio.Queue, args: Dict[str, Any]):
 
     urls = args.get("urls", [])
-    delay = args.get("delay", 1)
+    delay = int(args.get("delay", 1))
 
     if not urls:
         return


### PR DESCRIPTION
Typing is not enforced for "delay" and if, for example, you set it to "5" instead of 5 then ansible-events will not loop; it runs once and exits because asyncio.sleep will not accept a string. This is a problem if you use jinja templating in your rulebook since it will always parse as a string. 

https://issues.redhat.com/browse/AAP-5497